### PR TITLE
Fixed: a plugin registered with undefined options would throw an error

### DIFF
--- a/src/statsd.js
+++ b/src/statsd.js
@@ -35,7 +35,7 @@ module.exports.register = function (server, options, next) {
         if (request._route === specials.notFound.route) {
             path = '/{notFound*}';
         }
-        else if (request._route === specials.options.route) {
+        else if (specials.options !== null && request._route === specials.options.route) {
             path = '/{cors*}';
         }
         else if (request._route.path === '/' && request._route.method === 'options') {

--- a/test/index.js
+++ b/test/index.js
@@ -173,15 +173,19 @@ describe( 'bluestatsd()', () => {
         } );
 
         const get = (request, reply) => reply( 'Success!' );
-        const err = (request, reply) => reply( new Error() );
 
-        server.route( { method: ['GET', 'OPTIONS'], path: '/', handler: get, config: { cors: true } } );
-        server.route( { method: 'GET', path: '/err', handler: err, config: { cors: true } } );
-        server.route( { method: 'GET', path: '/test/{param}', handler: get, config: { cors: true } } );
+        server.route( { method: 'GET', path: '/test/{param}', handler: get });
 
         server.register( {
             register: Plugin
-        }, done );
+        }, () => {
+
+            server.inject( '/test/123', (res) => {
+
+                Assert( res.statusCode === 200 );
+                done();
+            } );
+        } );
     } );
 
 } );


### PR DESCRIPTION
The associated test ('should work with undefined options') was not injecting any request.

Coverage is kept at 100%. I tried respecting your guidelines but if there's anything I'm missing, feel free to tell me!
